### PR TITLE
Adding .parcel-cache/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 public/
 .DS_Store
 yarn-error.log
+.parcel-cache/


### PR DESCRIPTION
Parcel is storing caches in .parcel-cache instead of .cache