### PR TITLE
correction to example output

### DIFF
--- a/lessons/depth-first-tree-traversals.md
+++ b/lessons/depth-first-tree-traversals.md
@@ -55,7 +55,7 @@ Postorder traversal, as you have guessed, you recursively call the method on the
 [8, 3, 1, 6, 4, 7, 10, 14, 13]
 
 // inorder
-[1, 3, 5, 6, 7, 8, 10, 13, 14]
+[1, 3, 4, 6, 7, 8, 10, 13, 14]
 
 // postorder
 [1, 4, 7, 6, 3, 13, 14, 10, 8]


### PR DESCRIPTION
Changes `inorder[2]` from 5 to 4

Before:
<img width="466" alt="Screen Shot 2021-09-11 at 11 12 02 PM" src="https://user-images.githubusercontent.com/89322410/132974243-e6ef6e8e-7ff5-4850-8e2c-9affcca3fda3.png">

After:
```
// inorder
[1, 3, 4, 6, 7, 8, 10, 13, 14]
```